### PR TITLE
Fix botocore error, dockerize all the things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ RUN python3.10 -m venv /opt/venv
 # Install pip requirements
 RUN . /opt/venv/bin/activate && poetry install
 
-# TODO: dive + docker-slim
 FROM ubuntu:20.04 AS runner-image
 
 ARG USERNAME=appuser
@@ -99,5 +98,5 @@ USER appuser
 
 WORKDIR $HOME/app
 
-ENTRYPOINT ["python", "hello.py"]
-#CMD ["/bin/bash"]
+ENTRYPOINT ["python", "demo.py"]
+# CMD ["/bin/bash"]

--- a/demo.py
+++ b/demo.py
@@ -1,17 +1,34 @@
 #!/usr/bin/env python3
 
-import os
 import boto3
+import os
+from decouple import config
 from flask import Flask, render_template
+# from icecream import ic
+from pathlib import Path
 
-aws_access_key = os.environ.get('ACCESS_KEY_ID')
-aws_secret_key = os.environ.get('SECRET_ACCESS_KEY')
+# verbose icecream
+# ic.configureOutput(includeContext=True)
+
+home = Path.home()
+env = Path('.env')
+cwd = Path.cwd()
+
+if env.exists():
+    aws_access_key = config('ACCESS_KEY_ID', default='', cast=str)
+    aws_secret_key = config('SECRET_ACCESS_KEY', default='', cast=str)
+else:
+    aws_access_key = os.getenv('ACCESS_KEY_ID')
+    aws_secret_key = os.getenv('SECRET_ACCESS_KEY')
 
 app = Flask(__name__, template_folder='html')
+
 aws_session = boto3.Session(
     aws_access_key_id=aws_access_key,
     aws_secret_access_key=aws_secret_key,
+    region_name='us-east-1'
 )
+
 db_client = aws_session.client('dynamodb')
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,17 @@
-version: "3.7"
+version: "3.9"
 
 services:
   app:
-    container_name: hello
+    container_name: gitleaks-cont
     image: docker_python
-    tty: true               # remove for `entrypoint` in Dockerfile
-    stdin_open: true        # remove for `entrypoint` in Dockerfile
+    tty: false               # false for `entrypoint` in Dockerfile
+    stdin_open: false        # false for `entrypoint` in Dockerfile
+    env_file:
+      - ./.env
+    volumes:
+      - .:/home/appuser/app
+    ports:
+      - 8000:8000
     build:
-      context: .
+      context: ./
       dockerfile: ./Dockerfile


### PR DESCRIPTION
Hard-coded region — could switch to .env/env var, tightened up docker-compose vols, ports, and syntax.

Get running locally via
```bash
docker-compose build --parallel --force-rm
docker-compose up
```
then navigate to http://localhost:8000/.

Should add usage instructions to readme after you verify it works on your machine 😜 